### PR TITLE
[view][feature] アニメーション描画にループと完了時停止の機能追加

### DIFF
--- a/tile-view/src/app/main-canvas/main-canvas.component.html
+++ b/tile-view/src/app/main-canvas/main-canvas.component.html
@@ -7,5 +7,7 @@
   <button mat-button (click)="putRoadKoma(4)">put 4</button>
   <button mat-button (click)="putRoadKoma(5)">put 5</button>
   <button mat-button (click)="flashCanvas()">remove</button>
-  <button mat-button (click)="putTreasure()">宝箱アニメ</button>
+  <button mat-button (click)="putTreasure('ONCE')">アニメ(一度だけ)</button>
+  <button mat-button (click)="putTreasure('STOP')">アニメ(停止)</button>
+  <button mat-button (click)="putTreasure('LOOP')">アニメ(ループ)</button>
 </div>

--- a/tile-view/src/app/main-canvas/main-canvas.component.ts
+++ b/tile-view/src/app/main-canvas/main-canvas.component.ts
@@ -55,10 +55,10 @@ export class MainCanvasComponent implements OnInit {
 
   //for stream test
 
-  public putTreasure(){
+  public putTreasure(animationType:string){
     const tmpCommandData ={
       type: COMMAND_TYPE.TEST_TREASURE,
-      target: "test",
+      target: animationType,
       value: 0,
       message: "this is test message"
     };

--- a/tile-view/src/app/model/command.ts
+++ b/tile-view/src/app/model/command.ts
@@ -6,7 +6,6 @@ export const COMMAND_TYPE = {
   PUT_ROAD: 'PUT_ROAD',
   REMOVE_ROAD: 'REMOVE_ROAD',
   TEST_TREASURE: 'TEST_TREASURE',
-
 } as const;
 type COMMAND_TYPE = typeof COMMAND_TYPE[keyof typeof COMMAND_TYPE];
 

--- a/tile-view/src/app/model/drawable-object.ts
+++ b/tile-view/src/app/model/drawable-object.ts
@@ -1,6 +1,6 @@
 import * as p5 from 'p5';
 import { Point } from './point';
-import { Graphic, GRAPHIC_POSITION, toRadian } from './graphics';
+import { Graphic, AnimationStatus, ANIMATION_TYPE, toRadian, GRAPHIC_POSITION } from './graphics';
 
 export class DrawableObject {
   public p5ref:any
@@ -10,32 +10,15 @@ export class DrawableObject {
   public draw(){}
 }
 
-export class AnimationStatus{
-  maxFrame:number;
-  progress:number;
-  constructor(g:Graphic){
-    this.maxFrame = g.animationInfo.numOfFrames * g.animationInfo.framePerImage;
-    this.progress = 0;
-  }
-  public isFinished(){
-    //ここ = いらんかも
-    return this.progress >= this.maxFrame;
-  }
-  public terminate(){
-    this.maxFrame = 0;
-  }
-  public nextFrame(){
-    this.progress += 1;
-  }
-}
-
 export class DrawableAnimationObject extends DrawableObject {
   public animationStatus :AnimationStatus;
   public graphic:Graphic
-  constructor(p:p5,graphic:Graphic){
+  constructor(
+      p:p5,graphic:Graphic,
+      animationType:ANIMATION_TYPE = ANIMATION_TYPE.ONCE){
     super(p);
     this.graphic = graphic;
-    this.animationStatus = new AnimationStatus(graphic);
+    this.animationStatus = new AnimationStatus(graphic,animationType);
   }
   public draw(){}
 
@@ -93,7 +76,7 @@ export class TestTreasure extends DrawableAnimationObject {
   public graphic:Graphic;
   public position:number
   constructor(p:p5, pos:number, graphic:Graphic){
-    super(p,graphic);
+    super(p,graphic,ANIMATION_TYPE.STOP);
     this.graphic = graphic;
     this.position = pos;
   }

--- a/tile-view/src/app/model/drawable-object.ts
+++ b/tile-view/src/app/model/drawable-object.ts
@@ -75,10 +75,11 @@ export class RoadKoma extends DrawableObject {
 export class TestTreasure extends DrawableAnimationObject {
   public graphic:Graphic;
   public position:number
-  constructor(p:p5, pos:number, graphic:Graphic){
-    super(p,graphic,ANIMATION_TYPE.STOP);
+  // テスト用にアニメーションタイプを横付け
+  constructor(p:p5, animationType:any, graphic:Graphic){
+    super(p,graphic,animationType);
     this.graphic = graphic;
-    this.position = pos;
+    this.position = 0;
   }
   public draw(){
     const centerX = 300-90; 

--- a/tile-view/src/app/model/graphics.ts
+++ b/tile-view/src/app/model/graphics.ts
@@ -40,6 +40,11 @@ export const ANIMATION_TYPE = {
   LOOP: 'LOOP',
 } as const;
 export type ANIMATION_TYPE = typeof ANIMATION_TYPE[keyof typeof ANIMATION_TYPE];
+export function isAnimationType(str:string){
+  return str == ANIMATION_TYPE.ONCE || 
+         str == ANIMATION_TYPE.STOP || 
+         str == ANIMATION_TYPE.LOOP  
+}
 
 export class AnimationStatus{
   maxFrame:number;

--- a/tile-view/src/app/model/graphics.ts
+++ b/tile-view/src/app/model/graphics.ts
@@ -8,7 +8,6 @@ export function toRadian(degree:number){
   return degree/180*M_PI;
 }
 
-
 //TODO 変数名ごちゃっとしすぎか?
 // アニメーションのコマ割りデータ
 // AnimationInfo(numOfFrames, framePerImage, numOfWidth, numOfHeight, sizeOfWidth, sizeOfHeight)
@@ -33,6 +32,56 @@ export class AnimationInfo{
     this.sizeOfHeight = sizeOfHeight;
   }
 }
+
+// アニメーションのパターン
+export const ANIMATION_TYPE = {
+  ONCE: 'ONCE',
+  STOP: 'STOP',
+  LOOP: 'LOOP',
+} as const;
+export type ANIMATION_TYPE = typeof ANIMATION_TYPE[keyof typeof ANIMATION_TYPE];
+
+export class AnimationStatus{
+  maxFrame:number;
+  progress:number;
+  type: ANIMATION_TYPE;
+  constructor(g:Graphic,type:ANIMATION_TYPE = ANIMATION_TYPE.ONCE){
+    // 0 オリジンなので1引く
+    this.maxFrame = g.animationInfo.numOfFrames * g.animationInfo.framePerImage-1;
+    this.progress = 0;
+    this.type = type;
+  }
+
+  public isFinished(){
+    if(this.type === ANIMATION_TYPE.LOOP){
+      return false;
+    }if(this.type === ANIMATION_TYPE.STOP){
+      return false;
+    }else{
+      return this.progress >= this.maxFrame;
+    }
+  }
+  public terminate(){
+    // LOOP しないように設定
+    this.type = ANIMATION_TYPE.ONCE;
+    this.maxFrame = 0;
+  }
+  public nextFrame(){
+    //1ループ終わった かつ ループする設定ならば
+    if(this.progress >= this.maxFrame && this.type === ANIMATION_TYPE.LOOP){
+      //最初に戻す
+      this.progress = 0;
+    //1ループ終わった かつ ループする設定ならば
+    }else if(this.progress >= this.maxFrame && this.type === ANIMATION_TYPE.STOP){
+      // progress を進めない
+      this.progress += 0;
+    }else{
+      // それ以外は progress を進める
+      this.progress += 1;
+    }
+  }
+}
+
 
 // 画像素材一つの情報
 // アニメーション素材はそれで一つと考える

--- a/tile-view/src/app/model/player.ts
+++ b/tile-view/src/app/model/player.ts
@@ -1,0 +1,8 @@
+export PLAYER_COLOR = {
+  RED = "RED",
+  YELLOW = "YELLOW",
+  BLUE = "BLUE", 
+  WHITE "WHITE",
+} as const
+
+type PLAYER_COLOR = typeof PLAYER_COLOR[keyof typeof PLAYER_COLOR];

--- a/tile-view/src/app/service/view-command/view-command.service.ts
+++ b/tile-view/src/app/service/view-command/view-command.service.ts
@@ -9,6 +9,8 @@ import * as p5 from 'p5';
 import { GraphicService } from '../graphic/graphic.service'
 import { TestTreasure, RoadKoma, DrawableObject, DrawableAnimationObject } from '../../model/drawable-object' 
 import { CommandData, CommandInfo, COMMAND_TYPE} from '../../model/command' 
+// for test
+import { ANIMATION_TYPE, isAnimationType } from '../../model/graphics' 
 
 
 @Injectable({
@@ -94,8 +96,10 @@ export class ViewCommandService {
     this.drawableObjectList = [];
   }
   private execGenerateTreasure(cmd:CommandData){
-    this.drawableObjectList.push(
-      new TestTreasure(this.p5ref, cmd.value, this.graphicService.TEST_TREASURE)
-    );
+    if(isAnimationType(cmd.target)){
+      this.drawableObjectList.push(
+        new TestTreasure(this.p5ref, cmd.target, this.graphicService.TEST_TREASURE)
+      );
+    }
   }
 }


### PR DESCRIPTION
https://github.com/mznh/digital-catan/issues/29 へのPRです。
元々の 一度再生したら消滅 の挙動に加えて以下の2つを追加します。

 * 一度再生したら停止
 *  ループ再生

`DrawableAnimationObject` 生成時に `ANIMATION_TYPE` を指定することでこれらを切り替えます。

各タイプによる挙動の違いは `AnimationStatus` 内の `isFinished`, `nextFrame` で表現しています。